### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ An MCP server for [gitingest](https://github.com/cyclotruc/gitingest). This allo
 - Project directory structure
 - File content
 
+<a href="https://glama.ai/mcp/servers/g0dylqhn3h">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/g0dylqhn3h/badge" alt="Gitingest-MCP MCP server" />
+</a>
+
 https://github.com/user-attachments/assets/c1fa596b-a70b-4d37-91d9-ea5e80284793
 
 ## Table of Contents


### PR DESCRIPTION
This PR adds a badge for the [Gitingest-MCP](https://glama.ai/mcp/servers/g0dylqhn3h) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/g0dylqhn3h">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/g0dylqhn3h/badge" alt="Gitingest-MCP MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.